### PR TITLE
Removing outdated codeclimate-test-reporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Code Climate Test Reporter
-gem "codeclimate-test-reporter", group: :test, require: nil
+gem 'rspec', '~> 2.14.1'
 
 # Code coverage for Ruby 1.9+ with a powerful configuration library and
 # automatic merging of coverage across test suites

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
 # Require Code Climate Test Reporter
-require "codeclimate-test-reporter"
-
-# Starts Code Climate Test Reporter
-CodeClimate::TestReporter.start
+require 'rspec'
 
 # Require Coveralls for Test cover
 require 'coveralls'
@@ -11,5 +8,5 @@ require 'coveralls'
 Coveralls.wear!
 
 # Require other files of project
-require "lerolero_generator"
-require_relative "../lib/lerolero_generator/speech"
+require 'lerolero_generator'
+require_relative '../lib/lerolero_generator/speech'


### PR DESCRIPTION
This tool was deprecated, I removed it in favor of rspec as a temporary fix.